### PR TITLE
Feature/log fixes

### DIFF
--- a/Conan.VisualStudio.Tests/Menu/AddConanDependsTests.cs
+++ b/Conan.VisualStudio.Tests/Menu/AddConanDependsTests.cs
@@ -58,7 +58,7 @@ namespace Conan.VisualStudio.Tests.Menu
                 x => x.ShowPluginError(
                     $"Conan has returned exit code {exitCode}. Please check file '{logFilePath}' for details."));
             var logContent = File.ReadAllText(Path.Combine(directory, "conan.log"));
-            Assert.Equal($"conan-shim-error{Environment.NewLine}", logContent);
+            Assert.NotEmpty(logContent);
         }
 
         [Fact]

--- a/Conan.VisualStudio/Menu/AddConanDepends.cs
+++ b/Conan.VisualStudio/Menu/AddConanDepends.cs
@@ -62,14 +62,19 @@ namespace Conan.VisualStudio.Menu
                 await Task.Run(() => Directory.CreateDirectory(project.InstallPath));
                 var logFilePath = Path.Combine(project.InstallPath, "conan.log");
 
-                using (var reader = process.StandardOutput)
-                using (var logFile = File.Open(logFilePath, FileMode.Create))
+                using (var logFile = File.Open(logFilePath, FileMode.Create, FileAccess.Write, FileShare.Read))
                 using (var logStream = new StreamWriter(logFile))
                 {
-                    string line;
-                    while ((line = await reader.ReadLineAsync()) != null)
+                    await logStream.WriteLineAsync(
+                        $"Calling process '{process.StartInfo.FileName}'" +
+                        $" with arguments '{process.StartInfo.Arguments}'");
+                    using (var reader = process.StandardOutput)
                     {
-                        await logStream.WriteLineAsync(line);
+                        string line;
+                        while ((line = await reader.ReadLineAsync()) != null)
+                        {
+                            await logStream.WriteLineAsync(line);
+                        }
                     }
                 }
 

--- a/Conan.VisualStudio/Menu/AddConanDepends.cs
+++ b/Conan.VisualStudio/Menu/AddConanDepends.cs
@@ -58,6 +58,8 @@ namespace Conan.VisualStudio.Menu
             try
             {
                 var process = await conan.Install(project);
+
+                await Task.Run(() => Directory.CreateDirectory(project.InstallPath));
                 var logFilePath = Path.Combine(project.InstallPath, "conan.log");
 
                 using (var reader = process.StandardOutput)

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ It will call `conan install --build missing --update` using the
 [`visual_studio_multi` generator][visual_studio_multi]. After that, you'll need
 to integrate the resulting property files into your Visual Studio project.
 
+If you need any diagnostic information, please look for `conan/conan.log` file
+in the directory with your conanfile.
+
 ### Integration with project
 
 The [`visual_studio_multi` generator][visual_studio_multi] creates the


### PR DESCRIPTION
While investigating issue #31, I've found a couple of issues with the log files:

- `AddConanDepends` won't work if the install directory wasn't created defore trying to open a log file
- `AddConanDepends` doesn't allow a shared access to the log file while the command is executing (inconvenient)
- it's convenient to include the Conan path and arguments in the log file 
- the log file location wasn't documented

All of above are fixed by this PR.