### PR TITLE
Fix issues with test project

### DIFF
--- a/Conan.VisualStudio.Core/ConanConfiguration.cs
+++ b/Conan.VisualStudio.Core/ConanConfiguration.cs
@@ -1,0 +1,18 @@
+namespace Conan.VisualStudio.Core
+{
+    public class ConanConfiguration
+    {
+        public string Architecture { get; set; }
+        public string BuildType { get; set; }
+        public string CompilerToolset { get; set; }
+        public string CompilerVersion { get; set; }
+
+        public override string ToString()
+        {
+            return $"Architecture: {Architecture}, " +
+                   $"build type: {BuildType}, " +
+                   $"compiler toolset: {CompilerToolset}, " +
+                   $"compiler version: {CompilerVersion}";
+        }
+    }
+}

--- a/Conan.VisualStudio.Core/ConanPathHelper.cs
+++ b/Conan.VisualStudio.Core/ConanPathHelper.cs
@@ -7,6 +7,23 @@ namespace Conan.VisualStudio.Core
 {
     public static class ConanPathHelper
     {
+        /// <summary>
+        /// Returns a path to <paramref name="location"/> relative to <paramref name="baseDirectory" />. If the paths
+        /// aren't related, returns an absolute path to the <paramref name="location"/>.
+        /// </summary>
+        public static string GetRelativePath(string baseDirectory, string location)
+        {
+            if (!Path.GetFullPath(baseDirectory).EndsWith(Path.DirectorySeparatorChar.ToString()))
+            {
+                baseDirectory = Path.GetFullPath(baseDirectory) + Path.DirectorySeparatorChar;
+            }
+
+            var baseUri = new Uri(baseDirectory);
+            var locationUri = new Uri(location);
+            var relativeUri = baseUri.MakeRelativeUri(locationUri);
+            return Uri.UnescapeDataString(relativeUri.ToString()).Replace('/', Path.DirectorySeparatorChar);
+        }
+
         public static string DetermineConanPathFromEnvironment()
         {
             var path = Environment.GetEnvironmentVariable("PATH") ?? "";

--- a/Conan.VisualStudio.Core/ConanProject.cs
+++ b/Conan.VisualStudio.Core/ConanProject.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
+
 namespace Conan.VisualStudio.Core
 {
     public class ConanProject
     {
         public string Path { get; set; }
         public string InstallPath { get; set; }
-        public string CompilerVersion { get; set; }
+
+        public List<ConanConfiguration> Configurations { get; } = new List<ConanConfiguration>();
     }
 }

--- a/Conan.VisualStudio.Core/ConanRunner.cs
+++ b/Conan.VisualStudio.Core/ConanRunner.cs
@@ -11,7 +11,7 @@ namespace Conan.VisualStudio.Core
         public ConanRunner(string executablePath) =>
             _executablePath = executablePath;
 
-        public Task<Process> Install(ConanProject project)
+        public Task<Process> Install(ConanProject project, ConanConfiguration configuration)
         {
             string Escape(string arg) => arg.Contains(" ") ? $"\"{arg}\"" : arg;
             string ProcessArgument(string name, string value) => $"-s {name}={Escape(value)}";
@@ -20,11 +20,14 @@ namespace Conan.VisualStudio.Core
             const string generatorName = "visual_studio_multi";
             var settingValues = new[]
             {
-                ("compiler.version", project.CompilerVersion)
+                ("arch", configuration.Architecture),
+                ("build_type", configuration.BuildType),
+                ("compiler.toolset", configuration.CompilerToolset),
+                ("compiler.version", configuration.CompilerVersion)
             };
             const string options = "--build missing --update";
 
-            var settings = string.Join(" ", settingValues.Select(pair =>
+            var settings = string.Join(" ", settingValues.Where(pair => pair.Item2 != null).Select(pair =>
             {
                 var (key, value) = pair;
                 return ProcessArgument(key, value);

--- a/Conan.VisualStudio.Tests/Conan.VisualStudio.Tests.csproj
+++ b/Conan.VisualStudio.Tests/Conan.VisualStudio.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Core\ConanRunnerTests.cs" />
     <Compile Include="FileSystem.cs" />
     <Compile Include="Menu\AddConanDependsTests.cs" />
+    <Compile Include="Menu\IntegrateIntoProjectCommandTests.cs" />
     <Compile Include="Menu\MenuCommandBaseTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ResourceUtils.cs" />

--- a/Conan.VisualStudio.Tests/Conan.VisualStudio.Tests.csproj
+++ b/Conan.VisualStudio.Tests/Conan.VisualStudio.Tests.csproj
@@ -47,6 +47,7 @@
     <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.VCProjectEngine, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>

--- a/Conan.VisualStudio.Tests/Core/ConanPathHelperTests.cs
+++ b/Conan.VisualStudio.Tests/Core/ConanPathHelperTests.cs
@@ -8,6 +8,16 @@ namespace Conan.VisualStudio.Tests.Core
 {
     public class ConanPathHelperTests
     {
+        [Theory]
+        [InlineData(@"C:\", @"C:\Program Files", "Program Files")]
+        [InlineData(@"C:\Conan", @"C:\Conan\file.txt", "file.txt")]
+        [InlineData(@"C:\Conan\", @"C:\Conan\file.txt", "file.txt")]
+        [InlineData(@"C:\Conan", @"C:\Program Files", @"..\Program Files")]
+        [InlineData(@"C:\Conan", @"D:\Program Files", @"D:\Program Files")]
+        [InlineData(@"C:\Solution\Project", @"C:\Solution\conan\conanfile.props", @"..\conan\conanfile.props")]
+        public void GetRelativePathTests(string basePath, string location, string expectedRelativePath) =>
+            Assert.Equal(expectedRelativePath, ConanPathHelper.GetRelativePath(basePath, location));
+
         [Fact]
         public void ConanPathIsDeterminedAutomatically()
         {

--- a/Conan.VisualStudio.Tests/Core/ConanRunnerTests.cs
+++ b/Conan.VisualStudio.Tests/Core/ConanRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System.Threading.Tasks;
 using Conan.VisualStudio.Core;
 using Xunit;
@@ -14,12 +15,24 @@ namespace Conan.VisualStudio.Tests.Core
             {
                 Path = ".",
                 InstallPath = "./conan",
-                CompilerVersion = "15"
+                Configurations = 
+                {
+                    new ConanConfiguration
+                    {
+                        Architecture = "x86_64",
+                        BuildType = "Debug",
+                        CompilerToolset = "v141",
+                        CompilerVersion = "15"
+                    }
+                }
             };
-            using (var process = await conan.Install(project))
+            using (var process = await conan.Install(project, project.Configurations.Single()))
             {
                 Assert.Equal("install . -g visual_studio_multi " +
                              "--install-folder ./conan " +
+                             "-s arch=x86_64 " +
+                             "-s build_type=Debug " +
+                             "-s compiler.toolset=v141 " +
                              "-s compiler.version=15 " +
                              "--build missing --update", process.StartInfo.Arguments);
             }

--- a/Conan.VisualStudio.Tests/Menu/IntegrateIntoProjectCommandTests.cs
+++ b/Conan.VisualStudio.Tests/Menu/IntegrateIntoProjectCommandTests.cs
@@ -1,0 +1,39 @@
+using System.ComponentModel.Design;
+using System.IO;
+using System.Threading.Tasks;
+using Conan.VisualStudio.Menu;
+using Conan.VisualStudio.Services;
+using Microsoft.VisualStudio.VCProjectEngine;
+using Moq;
+using Xunit;
+
+namespace Conan.VisualStudio.Tests.Menu
+{
+    public class IntegrateIntoProjectCommandTests
+    {
+        [Fact]
+        public async Task IntegrateIntoProjectCommandCalculatesAProjectRelativePath()
+        {
+            var solutionDir = FileSystemUtils.CreateTempDirectory();
+            FileSystemUtils.CreateTempFile(solutionDir, "conanfile.txt");
+
+            var projectDir = Directory.CreateDirectory(Path.Combine(solutionDir, "Project")).FullName;
+            var projectPath = Path.Combine(projectDir, "Project.vcxproj");
+
+            var project = new Mock<VCProject>();
+            project.Setup(p => p.ProjectDirectory).Returns(projectDir);
+            project.Setup(p => p.ProjectFile).Returns(projectPath);
+
+            var projectService = new Mock<IVcProjectService>();
+            projectService.Setup(p => p.GetActiveProject()).Returns(project.Object);
+
+            var command = new IntegrateIntoProjectCommand(
+                Mock.Of<IMenuCommandService>(),
+                Mock.Of<IDialogService>(),
+                projectService.Object);
+            await command.MenuItemCallback();
+
+            projectService.Verify(p => p.AddPropsImport(projectPath, @"..\conan\conanbuildinfo_multi.props"));
+        }
+    }
+}

--- a/Conan.VisualStudio.Tests/Services/VcProjectServiceTests.cs
+++ b/Conan.VisualStudio.Tests/Services/VcProjectServiceTests.cs
@@ -1,13 +1,66 @@
+using System;
+using System.Dynamic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Conan.VisualStudio.Services;
+using Microsoft.VisualStudio.VCProjectEngine;
+using Moq;
 using Xunit;
 
 namespace Conan.VisualStudio.Tests.Services
 {
     public class VcProjectServiceTests
     {
+        private readonly IVcProjectService _service = new VcProjectService();
+
+        [Fact]
+        public void GetArchitrectureSupportsTheNecessaryArchitectures()
+        {
+            Assert.Equal("x86", VcProjectService.GetArchitecture("Win32"));
+            Assert.Equal("x86_64", VcProjectService.GetArchitecture("x64"));
+        }
+
+        [Fact]
+        public void GetBuildTypeReturnsItsArgument()
+        {
+            var configurationName = Guid.NewGuid().ToString();
+            Assert.Equal(configurationName, VcProjectService.GetBuildType(configurationName));
+        }
+
+        [Fact]
+        public async Task ExtractConanProjectExtractsThePathsProperly()
+        {
+            var directory = FileSystemUtils.CreateTempDirectory();
+            FileSystemUtils.CreateTempFile(directory, "conanfile.txt");
+            var installPath = Path.Combine(directory, "conan");
+
+            var vcProject = MockVcProject(directory);
+
+            var project = await _service.ExtractConanProject(vcProject);
+            Assert.Equal(directory, project.Path);
+            Assert.Equal(installPath, project.InstallPath);
+        }
+
+        [Fact]
+        public async Task ExtractConanConfigurationExtractsAllTheData()
+        {
+            var directory = FileSystemUtils.CreateTempDirectory();
+            FileSystemUtils.CreateTempFile(directory, "conanfile.txt");
+
+            var vcConfiguration = MockVcConfiguration("Win32", "Debug", "v141");
+            var vcProject = MockVcProject(directory, vcConfiguration);
+
+            var project = await _service.ExtractConanProject(vcProject);
+            var configuration = project.Configurations.Single();
+
+            Assert.Equal("x86", configuration.Architecture);
+            Assert.Equal("Debug", configuration.BuildType);
+            Assert.Equal("v141", configuration.CompilerToolset);
+            Assert.Equal("15", configuration.CompilerVersion);
+        }
+
         [Theory]
         [InlineData(@"<?xml version=""1.0"" encoding=""utf-8""?>
 <Project DefaultTargets=""Build"" ToolsVersion=""15.0"" xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
@@ -32,6 +85,38 @@ namespace Conan.VisualStudio.Tests.Services
             XNamespace ns = "http://schemas.microsoft.com/developer/msbuild/2003";
             var imports = document.Root.Descendants(ns + "Import");
             Assert.Single(imports, import => import.Attribute("Project").Value == propFilePath);
+        }
+
+        private VCProject MockVcProject(string directory, params VCConfiguration[] configurations)
+        {
+            var project = new Mock<VCProject>();
+            project.Setup(p => p.ProjectDirectory).Returns(directory);
+            project.Setup(p => p.Configurations).Returns(configurations);
+            return project.Object;
+        }
+
+        private VCConfiguration MockVcConfiguration(string platformName, string configurationName, string platformToolset)
+        {
+            var configuration = new Mock<VCConfiguration>();
+            configuration.Setup(c => c.ConfigurationName).Returns(configurationName);
+
+            object MockPlatform()
+            {
+                dynamic platform = new ExpandoObject();
+                platform.Name = platformName;
+                return platform;
+            }
+
+            configuration.Setup(c => c.Platform).Returns(MockPlatform());
+
+            var generalSettings = new Mock<IVCRulePropertyStorage>();
+            generalSettings.Setup(s => s.GetEvaluatedPropertyValue("PlatformToolset")).Returns(platformToolset);
+
+            var rulesCollection = new Mock<IVCCollection>();
+            rulesCollection.Setup(c => c.Item("ConfigurationGeneral")).Returns(generalSettings.Object);
+            configuration.Setup(c => c.Rules).Returns(rulesCollection.Object);
+
+            return configuration.Object;
         }
     }
 }

--- a/Conan.VisualStudio/Menu/IntegrateIntoProjectCommand.cs
+++ b/Conan.VisualStudio/Menu/IntegrateIntoProjectCommand.cs
@@ -1,5 +1,7 @@
 using System.ComponentModel.Design;
+using System.IO;
 using System.Threading.Tasks;
+using Conan.VisualStudio.Core;
 using Conan.VisualStudio.Services;
 
 namespace Conan.VisualStudio.Menu
@@ -21,10 +23,14 @@ namespace Conan.VisualStudio.Menu
             _vcProjectService = vcProjectService;
         }
 
-        protected internal override Task MenuItemCallback()
+        protected internal override async Task MenuItemCallback()
         {
             var project = _vcProjectService.GetActiveProject();
-            return _vcProjectService.AddPropsImport(project.ProjectFile, @"conan\conanbuildinfo_multi.props");
+            var projectDirectory = project.ProjectDirectory;
+            var conanfileDirectory = await ConanPathHelper.GetNearestConanfilePath(projectDirectory);
+            var propFilePath = Path.Combine(conanfileDirectory, @"conan\conanbuildinfo_multi.props");
+            var relativePropFilePath = ConanPathHelper.GetRelativePath(projectDirectory, propFilePath);
+            await _vcProjectService.AddPropsImport(project.ProjectFile, relativePropFilePath);
         }
     }
 }

--- a/Conan.VisualStudio/Services/IVcProjectService.cs
+++ b/Conan.VisualStudio/Services/IVcProjectService.cs
@@ -7,7 +7,7 @@ namespace Conan.VisualStudio.Services
     public interface IVcProjectService
     {
         VCProject GetActiveProject();
-        Task<ConanProject> ExtractConanConfiguration(VCProject project);
+        Task<ConanProject> ExtractConanProject(VCProject vcProject);
         Task AddPropsImport(string projectPath, string propFilePath);
     }
 }

--- a/Conan.VisualStudio/Services/VcProjectService.cs
+++ b/Conan.VisualStudio/Services/VcProjectService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -31,19 +32,45 @@ namespace Conan.VisualStudio.Services
             return projects.Cast<Project>().Where(IsCppProject).Select(p => p.Object).OfType<VCProject>().FirstOrDefault();
         }
 
-        public async Task<ConanProject> ExtractConanConfiguration(VCProject project)
+        public async Task<ConanProject> ExtractConanProject(VCProject vcProject)
         {
-            var projectPath = await ConanPathHelper.GetNearestConanfilePath(project.ProjectDirectory);
-            if (projectPath == null)
-            {
-                throw new Exception($"Cannot find conanfile in any of parents of {project.ProjectDirectory}");
-            }
-
-            var installPath = Path.Combine(projectPath, "conan");
-            return new ConanProject
+            var projectPath = await ConanPathHelper.GetNearestConanfilePath(vcProject.ProjectDirectory);
+            var project = new ConanProject
             {
                 Path = projectPath,
-                InstallPath = installPath,
+                InstallPath = Path.Combine(projectPath, "conan")
+            };
+
+            foreach (VCConfiguration configuration in vcProject.Configurations)
+            {
+                project.Configurations.Add(ExtractConanConfiguration(configuration));
+            }
+
+            return project;
+        }
+
+        internal static string GetArchitecture(string platformName)
+        {
+            switch (platformName)
+            {
+                case "Win32": return "x86";
+                case "x64": return "x86_64";
+                default: throw new NotSupportedException($"Platform {platformName} is not supported by the Conan plugin");
+            }
+        }
+
+        internal static string GetBuildType(string configurationName) => configurationName;
+
+        private static ConanConfiguration ExtractConanConfiguration(VCConfiguration configuration)
+        {
+            var x = configuration.Platform;
+            IVCRulePropertyStorage generalSettings = configuration.Rules.Item("ConfigurationGeneral");
+            var toolset = generalSettings.GetEvaluatedPropertyValue("PlatformToolset");
+            return new ConanConfiguration
+            {
+                Architecture = GetArchitecture(configuration.Platform.Name),
+                BuildType = GetBuildType(configuration.ConfigurationName),
+                CompilerToolset = toolset,
                 CompilerVersion = "15"
             };
         }


### PR DESCRIPTION
Fixed all the remaining issues when trying to use the plugin on the test project.

1. It turned out that we actually need to execute Conan for each (toolset, configuration, platform) triple. It then generates the prop files and adds the links to the `conanbuildinfo_multi.prop` file.
2. We weren't properly resolving relative file paths in the `IntegrateIntoProjectFileCommand`, so it weren't working for the case when the `conanfile.txt` is placed in the solution directory.

Also I've added more tests for the `VcProjectService` class.

Closes #31.